### PR TITLE
Azure Table Storage Tests and associated prod code changes

### DIFF
--- a/com.brgs.orm.test/AzureStorageTablePostsTests.cs
+++ b/com.brgs.orm.test/AzureStorageTablePostsTests.cs
@@ -53,6 +53,36 @@ namespace com.brgs.orm.test
             var val = fac.Post<RiverEntity>(river);
             Assert.NotNull(val);
         }
+        [Fact]
+        public void DoesPostToTable_NonEntityObject()
+        {
+            var river = new River()
+            {
+                Name = "GAULEY RIVER BELOW SUMMERSVILLE DAM, WV",
+                RiverId = "03189600",
+                State = "West Virginia",
+                StateCode = "WV",
+                Srs = "EPSG:4326",
+                Latitude = "38.2151103",
+                Longitude = "-80.8881536", 
+                Id="Gauley|03189600"
+
+            };            
+            var acc = new Mock<ICloudStorageAccount>();
+            var tableClient = new Mock<CloudTableClient>(new Uri("https://www.google.com"), new StorageCredentials());
+            var table = new Mock<CloudTable>(new Uri("https://www.google.com"));
+            tableClient.Setup(tc => tc.GetTableReference(It.IsAny<string>())).Returns(table.Object);
+            acc.Setup(a => a.CreateCloudTableClient()).Returns(tableClient.Object);
+            var fac = new AzureStorageFactory(acc.Object)
+            {
+                PartitionKey = "TACOS",
+                CollectionName = "Pizza"
+            };
+
+
+            var val = fac.Post<River>(river);
+            Assert.NotNull(val);
+        }
 
     }
 }

--- a/com.brgs.orm.test/AzureStorageTablePostsTests.cs
+++ b/com.brgs.orm.test/AzureStorageTablePostsTests.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Moq;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Extensions.Configuration;
+
+using com.brgs.orm;
+using Microsoft.WindowsAzure.Storage.Auth;
+using System.Reflection;
+using System.Linq;
+using System.IO;
+using System.Text;
+using Newtonsoft.Json;
+using Microsoft.WindowsAzure.Storage.Table;
+
+namespace com.brgs.orm.test
+{
+    public class AzureStorageTablePostTests
+    {
+        [Fact]
+        public void WeCanTestPostingToTables()
+        {
+            var river = new RiverEntity()
+            {
+                Name = "GAULEY RIVER BELOW SUMMERSVILLE DAM, WV",
+                RiverId = "03189600",
+                State = "West Virginia",
+                StateCode = "WV",
+                Srs = "EPSG:4326",
+                Latitude = "38.2151103",
+                Longitude = "-80.8881536", 
+                Id="Gauley|03189600",
+                RowKey = Guid.NewGuid().ToString(),
+                PartitionKey = Guid.NewGuid().ToString(),
+                ETag = "POST",
+                Timestamp = DateTime.Now
+
+            };
+            var acc = new Mock<ICloudStorageAccount>();
+            var tableClient = new Mock<CloudTableClient>(new Uri("https://www.google.com"), new StorageCredentials());
+            var table = new Mock<CloudTable>(new Uri("https://www.google.com"));
+            tableClient.Setup(tc => tc.GetTableReference(It.IsAny<string>())).Returns(table.Object);
+            acc.Setup(a => a.CreateCloudTableClient()).Returns(tableClient.Object);
+            var fac = new AzureStorageFactory(acc.Object)
+            {
+                PartitionKey = "TACOS",
+                CollectionName = "Pizza"
+            };
+
+
+            var val = fac.Post<RiverEntity>(river);
+            Assert.NotNull(val);
+        }
+
+    }
+}

--- a/com.brgs.orm.test/AzureStorageTestsBlobGet.cs
+++ b/com.brgs.orm.test/AzureStorageTestsBlobGet.cs
@@ -12,7 +12,6 @@ using System.Reflection;
 using System.Linq;
 using System.IO;
 using System.Text;
-using System.Runtime.Serialization.Formatters.Binary;
 using Newtonsoft.Json;
 
 namespace com.brgs.orm.test

--- a/com.brgs.orm.test/AzureStorageTestsBlobGet.cs
+++ b/com.brgs.orm.test/AzureStorageTestsBlobGet.cs
@@ -10,6 +10,10 @@ using com.brgs.orm;
 using Microsoft.WindowsAzure.Storage.Auth;
 using System.Reflection;
 using System.Linq;
+using System.IO;
+using System.Text;
+using System.Runtime.Serialization.Formatters.Binary;
+using Newtonsoft.Json;
 
 namespace com.brgs.orm.test
 {
@@ -23,19 +27,28 @@ namespace com.brgs.orm.test
             var blobContainer = new Mock<CloudBlobContainer>(new Uri("https://www.google.com"));
 
             var blob = new Mock<CloudBlob>(new Uri("https://waterfinder.blob.core.windows.net/data"));
-            blob.Setup
-
-            blobContainer.Setup(bc => bc.GetBlobReference(It.IsAny<string>())).Returns(blob.Object);
-            blobClient.Setup(b => b.GetContainerReference(It.IsAny<string>())).Returns(blobContainer.Object);
-
-            acc.Setup(c => c.CreateCloudBlobClient()).Returns(blobClient.Object);
-
-            var fac = new AzureStorageFactory(acc.Object)
-            {
-                CollectionName ="PIZZA"
+            var riverList = new List<River>(){
+                new River()
             };
-            var stuff = fac.Get<List<River>>("TACOS");
-            Assert.NotEmpty(stuff);
+            var listString = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(riverList));
+
+            using (var val = new MemoryStream(listString))
+            {
+                blob.Setup(b =>b.OpenReadAsync()).ReturnsAsync(val);
+                blobContainer.Setup(bc => bc.GetBlobReference(It.IsAny<string>())).Returns(blob.Object);
+                blobClient.Setup(b => b.GetContainerReference(It.IsAny<string>())).Returns(blobContainer.Object);
+
+                acc.Setup(c => c.CreateCloudBlobClient()).Returns(blobClient.Object);
+
+                var fac = new AzureStorageFactory(acc.Object)
+                {
+                    CollectionName ="PIZZA"
+                };
+                var stuff = fac.Get<List<River>>("TACOS");
+                Assert.NotEmpty(stuff);
+            }
+            
+
         }
     }
 }

--- a/com.brgs.orm.test/AzureStorageTestsBlobGet.cs
+++ b/com.brgs.orm.test/AzureStorageTestsBlobGet.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Moq;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Extensions.Configuration;
+
+using com.brgs.orm;
+using Microsoft.WindowsAzure.Storage.Auth;
+using System.Reflection;
+using System.Linq;
+
+namespace com.brgs.orm.test
+{
+    public class AzureStorageBlobTests
+    {
+        [Fact]
+        public void WeDoGetDataFromBlobStorage()
+        {
+            var acc = new Mock<ICloudStorageAccount>();
+            var blobClient = new Mock<CloudBlobClient>(new Uri("https://ww.google.com"), new StorageCredentials());
+            var blobContainer = new Mock<CloudBlobContainer>(new Uri("https://www.google.com"));
+
+            var blob = new Mock<CloudBlob>(new Uri("https://waterfinder.blob.core.windows.net/data"));
+            blob.Setup
+
+            blobContainer.Setup(bc => bc.GetBlobReference(It.IsAny<string>())).Returns(blob.Object);
+            blobClient.Setup(b => b.GetContainerReference(It.IsAny<string>())).Returns(blobContainer.Object);
+
+            acc.Setup(c => c.CreateCloudBlobClient()).Returns(blobClient.Object);
+
+            var fac = new AzureStorageFactory(acc.Object)
+            {
+                CollectionName ="PIZZA"
+            };
+            var stuff = fac.Get<List<River>>("TACOS");
+            Assert.NotEmpty(stuff);
+        }
+    }
+}

--- a/com.brgs.orm.test/DemoClass.cs
+++ b/com.brgs.orm.test/DemoClass.cs
@@ -1,0 +1,13 @@
+using System;
+namespace com.brgs.orm.test
+{
+    internal class DemoEntity
+    {
+        public bool BoolProp { get; set; }
+        public double DoubleProp { get; set; }
+        public int IntProp { get; set; }
+        public long LongProp { get; set; }
+        public DateTime DateProp { get; set; }
+
+    }
+}

--- a/com.brgs.orm.test/River.cs
+++ b/com.brgs.orm.test/River.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+
 namespace com.brgs.orm.test
 {
     internal class River
@@ -24,5 +28,22 @@ namespace com.brgs.orm.test
         public object Value { get; set; }
         public string Flow { get; set; }
         public string Level { get; set; }        
+    }
+    internal class RiverEntity : River, ITableEntity
+    {
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+        public string ETag { get; set; }
+
+        public void ReadEntity(IDictionary<string, EntityProperty> properties, OperationContext operationContext)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/com.brgs.orm.test/TableEntityBuilderTypeTests.cs
+++ b/com.brgs.orm.test/TableEntityBuilderTypeTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using Moq;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using com.brgs.orm.helpers;
+
+namespace com.brgs.orm.test
+{
+    internal class DemoEntity
+    {
+        public bool BoolProp { get; set; }
+        public double DoubleProp { get; set; }
+
+    }
+    public class TableEntityPropertyTests
+    {
+        [Fact]
+        public void TableEntityBuilder_EncodesBoolProp()
+        {
+            var demo = new DemoEntity()
+            {
+                BoolProp = true
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            Assert.True(entity.Properties.ContainsKey("BoolProp"));
+        }
+        [Fact]
+        public void TableEntityBuilder_RetrievesAppropriateBooleanValue()
+        {
+            var demo = new DemoEntity()
+            {
+                BoolProp = true
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+
+            Assert.True(entity.Properties["BoolProp"].BooleanValue);            
+        }
+        [Fact]
+        public void TableEntityBuilder_EncodesDoubleProp()
+        {
+            var demo = new DemoEntity()
+            {
+                BoolProp = true,
+                DoubleProp = Convert.ToDouble(42)
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            Assert.True(entity.Properties.ContainsKey("DoubleProp"));
+            Assert.Equal(Convert.ToDouble(42), entity.Properties["DoubleProp"].DoubleValue);
+        }
+        [Fact]
+        public void TableEntityBuilder_RetrievesAppropriateDoubleValue()
+        {
+            var demo = new DemoEntity()
+            {
+                DoubleProp = Convert.ToDouble(42)
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            Assert.Equal(Convert.ToDouble(42), entity.Properties["DoubleProp"].DoubleValue);            
+        }
+    }
+}

--- a/com.brgs.orm.test/TableEntityBuilderTypeTests.cs
+++ b/com.brgs.orm.test/TableEntityBuilderTypeTests.cs
@@ -9,12 +9,7 @@ using com.brgs.orm.helpers;
 
 namespace com.brgs.orm.test
 {
-    internal class DemoEntity
-    {
-        public bool BoolProp { get; set; }
-        public double DoubleProp { get; set; }
 
-    }
     public class TableEntityPropertyTests
     {
         [Fact]
@@ -51,7 +46,6 @@ namespace com.brgs.orm.test
             var helper = new AzureFormatHelper(string.Empty);
             var entity = helper.BuildTableEntity(demo);
             Assert.True(entity.Properties.ContainsKey("DoubleProp"));
-            Assert.Equal(Convert.ToDouble(42), entity.Properties["DoubleProp"].DoubleValue);
         }
         [Fact]
         public void TableEntityBuilder_RetrievesAppropriateDoubleValue()
@@ -62,7 +56,56 @@ namespace com.brgs.orm.test
             };
             var helper = new AzureFormatHelper(string.Empty);
             var entity = helper.BuildTableEntity(demo);
-            Assert.Equal(Convert.ToDouble(42), entity.Properties["DoubleProp"].DoubleValue);            
+            var testVal = (DemoEntity)helper.RecastEntity(entity, typeof(DemoEntity));
+            Assert.Equal(demo.DoubleProp, testVal.DoubleProp);            
         }
+        [Fact]
+        public void TableEntityBuilder_EncodesIntProp()
+        {
+            var demo = new DemoEntity()
+            {
+                IntProp = 42
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            Assert.True(entity.Properties.ContainsKey("IntProp"));
+        }
+        [Fact]
+        public void TableEntityBuilder_EncodesInt64Prop()
+        {
+            var demo = new DemoEntity()
+            {
+                LongProp = Convert.ToInt64(42)
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            Assert.True(entity.Properties.ContainsKey("LongProp"));            
+        }
+        [Fact]
+        public void TableEntityBuilder_CastsAndEncodesDateTime()
+        {
+            var demo = new DemoEntity()
+            {
+                DateProp = DateTime.Now
+            };
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            Assert.True(entity.Properties.ContainsKey("DateProp"));
+        }
+        [Fact]
+        public void TableEntityBuilder_AppropriateDateValue()
+        {
+            var demo = new DemoEntity()
+            {
+                DateProp = DateTime.UtcNow
+            };
+            var date = DateTime.Now.ToUniversalTime();
+            var helper = new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            var testVal = (DemoEntity)helper.RecastEntity(entity, typeof(DemoEntity));
+            Assert.Equal(demo.DateProp, testVal.DateProp);
+
+        }
+
     }
 }

--- a/com.brgs.orm.test/TableEntityDecoderTests.cs
+++ b/com.brgs.orm.test/TableEntityDecoderTests.cs
@@ -28,9 +28,22 @@ namespace com.brgs.orm.test
             var helper = new AzureFormatHelper("pizza");
             var entity = helper.BuildTableEntity(river);
 
-            var testVal = (River)AzureFormatHelper.RecastEntity(entity, typeof(River));
+            var testVal = (River)helper.RecastEntity(entity, typeof(River));
             Assert.Equal(river.Name, testVal.Name);
             Assert.Equal(river.RiverId, testVal.RiverId);
+        }
+        [Fact]
+        public void TableEntityDecoder_DoesDecodeDates()
+        {
+            var demo = new DemoEntity()
+            {
+                DateProp = DateTime.UtcNow
+            };
+            var helper =  new AzureFormatHelper(string.Empty);
+            var entity = helper.BuildTableEntity(demo);
+            var testVal = (DemoEntity)helper.RecastEntity(entity, typeof(DemoEntity));
+            Assert.Equal(demo.DateProp, testVal.DateProp);
+
         }        
     }
-}   
+}

--- a/com.brgs.orm.test/TableEntityDecoderTests.cs
+++ b/com.brgs.orm.test/TableEntityDecoderTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 using Moq;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
-
 using com.brgs.orm.helpers;
 
 namespace com.brgs.orm.test

--- a/com.brgs.orm.test/TableEntityDecoderTypeTests.cs
+++ b/com.brgs.orm.test/TableEntityDecoderTypeTests.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+using Moq;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Table;
+using com.brgs.orm.helpers;
+
+namespace com.brgs.orm.test
+{
+    public class TableEntityDecoderTypeTests
+    {
+
+    }
+}

--- a/com.brgs.orm/AzureStorageFactory.cs
+++ b/com.brgs.orm/AzureStorageFactory.cs
@@ -108,24 +108,5 @@ namespace com.brgs.orm
                 throw new Exception(e.RequestInformation.ExtendedErrorInformation.ToString());
             }
         }
-        public IEnumerable<T> GetMultiple<T>(string name)
-        {
-            return GetEnumerableAsync<T>(CollectionName, name).Result;
-        }        
-        private async Task<IEnumerable<T>> GetEnumerableAsync<T>(string containerName, string blobName)
-        {
-            var blobClient = account.CreateCloudBlobClient();
-            var container = blobClient.GetContainerReference(containerName);
-            var blob = container.GetBlobReference(blobName);
-
-            var riverStream = await blob.OpenReadAsync();
-            using(StreamReader reader = new StreamReader(riverStream)){
-                string json = reader.ReadToEnd();
-                var list = JsonConvert.DeserializeObject<IEnumerable<T>>(json);
-
-
-                return list;
-            }            
-        }
     }
 }

--- a/com.brgs.orm/AzureStorageFactory.cs
+++ b/com.brgs.orm/AzureStorageFactory.cs
@@ -17,10 +17,12 @@ namespace com.brgs.orm
         private ICloudStorageAccount account;
         public string CollectionName { get; set; }
         public string PartitionKey { get; set; }
+        private AzureFormatHelper helper { get; set; }
 
         public AzureStorageFactory(ICloudStorageAccount acc)
         {
             account = acc;
+            helper = new AzureFormatHelper();
         }
         public T Get<T>( string blobName)
         {
@@ -60,12 +62,12 @@ namespace com.brgs.orm
                 {
                     if (outVal.GetType().GetMethod("Add") != null && content != null)
                     {
-                        var val =  AzureFormatHelper.RecastEntity(entity, content);
+                        var val =  helper.RecastEntity(entity, content);
                         outVal.GetType().GetMethod("Add").Invoke(outVal, new object[] { val });
                     }
                     else
                     { 
-                        return (T)AzureFormatHelper.RecastEntity(entity, typeof(T));
+                        return (T)helper.RecastEntity(entity, typeof(T));
                     }
                 }
 

--- a/com.brgs.orm/FileStorageFactory.cs
+++ b/com.brgs.orm/FileStorageFactory.cs
@@ -12,11 +12,6 @@ namespace com.brgs.orm
         {
             
         }
-        public IEnumerable<T> GetMultiple<T>(string filename)
-        {
-            throw new NotImplementedException();
-        }
-
         public T Get<T>(string filename)
         {
             throw new NotImplementedException();

--- a/com.brgs.orm/Helpers/AzureStorageHelpers.cs
+++ b/com.brgs.orm/Helpers/AzureStorageHelpers.cs
@@ -16,7 +16,7 @@ namespace com.brgs.orm.helpers
         {
             PartitionKey = key;
         }
-        public static object RecastEntity(DynamicTableEntity entity, Type type)
+        public object RecastEntity(DynamicTableEntity entity, Type type)
         {
             var decoder = new TableEntityDecoder(type);
             foreach (var property in entity.Properties)

--- a/com.brgs.orm/Helpers/TableEntityBuilder.cs
+++ b/com.brgs.orm/Helpers/TableEntityBuilder.cs
@@ -17,7 +17,8 @@ namespace com.brgs.orm.helpers
                 { "System.Boolean", new Action<string, dynamic>(AddBooleanProperty) },
                 { "System.Double", new Action<string, dynamic>(AddDoubleProperty) },
                 { "System.Int32", new Action<string, dynamic>(AddInt32Property) },
-                { "System.Int64", new Action<string, dynamic>(AddInt64Property) }
+                { "System.Int64", new Action<string, dynamic>(AddInt64Property) },
+                { "System.DateTime", new Action<string, dynamic>(AddDateTimeProperty) }
             };
         }
         public Dictionary<string, EntityProperty> Properties 
@@ -40,7 +41,8 @@ namespace com.brgs.orm.helpers
                 { "System.Boolean", new Action<string, dynamic>(AddBooleanProperty) },
                 { "System.Double", new Action<string, dynamic>(AddDoubleProperty) },
                 { "System.Int32", new Action<string, dynamic>(AddInt32Property) },
-                { "System.Int64", new Action<string, dynamic>(AddInt64Property) }
+                { "System.Int64", new Action<string, dynamic>(AddInt64Property) },
+                { "System.DateTime", new Action<string, dynamic>(AddDateTimeProperty) }
             };            
         }
         public void EncodeProperty<T>(PropertyInfo prop, T record)
@@ -50,8 +52,6 @@ namespace com.brgs.orm.helpers
                 Mapper[prop.PropertyType.ToString()].DynamicInvoke(prop.Name, prop.GetValue(record));
             }            
         }
-
-
         private void AddInt32Property(string name, dynamic value)
         {
             if(name != null && value != null && properties != null && !properties.ContainsKey(name) )
@@ -88,6 +88,17 @@ namespace com.brgs.orm.helpers
             {
                 properties.Add(name, new EntityProperty((string) value));
             } 
+        }
+        private void AddDateTimeProperty(string name, dynamic value)
+        {
+            if(name != null && value != null && properties != null
+                && !properties.ContainsKey(name))
+            {
+                var date = (DateTime) value;
+                var utcDate = date.ToUniversalTime();
+                properties.Add(name, new EntityProperty(utcDate));
+            }
+
         }
     }
 }

--- a/com.brgs.orm/IStorageFactory.cs
+++ b/com.brgs.orm/IStorageFactory.cs
@@ -8,7 +8,6 @@ namespace com.brgs.orm
     {
         string CollectionName { get; set; }
         string PartitionKey { get; set; }
-        IEnumerable<T> GetMultiple<T>(string filename);
         T Get<T>(string filename); 
         T Get<T>(TableQuery query);
 

--- a/com.brgs.orm/SqlStorageFactory.cs
+++ b/com.brgs.orm/SqlStorageFactory.cs
@@ -57,10 +57,6 @@ namespace com.brgs.orm
             }
             return outVal;
         }
-        public IEnumerable<T> GetMultiple<T>(string val)
-        {
-            throw new NotImplementedException("we're refactoring this away");
-        }
         public T Post<T>(T record) {throw new NotImplementedException("coming soon");}
         public T Post<T>()
         {

--- a/com.brgs.orm/com.brgs.orm.csproj
+++ b/com.brgs.orm/com.brgs.orm.csproj
@@ -6,7 +6,7 @@
     <Authors>Luke Badgerow</Authors>
     <Copyright>2019 Luke Badgerow</Copyright>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.0.8</Version>
+    <Version>0.0.9</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR mocks out the dependency on Azure Table Storage/ CloudStorageAccount so that we can more effectively test the buried logic, also it removes the dependency of having an actual storage account to pull data from during the testing process.